### PR TITLE
Feature/add untappd support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,11 @@
-FROM zeruel92/dart-armv7:latest
+FROM dart:2.17.1 AS build
 
-#Install git
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git
-
-#Get req. Dart SDK
-WORKDIR /opt/sdk
-RUN wget https://storage.googleapis.com/dart-archive/channels/stable/release/2.17.6/sdk/dartsdk-linux-arm-release.zip
-
-RUN unzip -o dartsdk-linux-arm-release.zip
-RUN rm dartsdk-linux-arm-release.zip
-
-#Prep. Dart code
 WORKDIR /opt/app
-RUN cd .. && ls
 
-ADD pubspec.* /opt/app/
-RUN pub get
-ADD . /opt/app
+#Prep code
+COPY pubspec.* ./
+RUN dart pub get
+COPY . .
 
 #Run bot
 CMD ["dart", "bin/beer_bot.dart"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 #Get req. Dart SDK
 WORKDIR /opt/sdk
-RUN wget https://storage.googleapis.com/dart-archive/channels/beta/release/2.16.0-80.1.beta/sdk/dartsdk-linux-arm-release.zip
+RUN wget https://storage.googleapis.com/dart-archive/channels/stable/release/2.17.6/sdk/dartsdk-linux-arm-release.zip
 
 RUN unzip -o dartsdk-linux-arm-release.zip
 RUN rm dartsdk-linux-arm-release.zip

--- a/README.md
+++ b/README.md
@@ -1,2 +1,82 @@
-# Agent S: The Dart Discord bot for beer lovers in Sweden
-Agent S is a Discord bot written in Dart utilizing the [Nyxx Framework](https://github.com/l7ssha/nyxx), which fetches beer release information from [Systembevakningsagenten.se](https://systembevakningsagenten.se/).
+# Agent Hops: The Dart Discord bot for beer lovers in Sweden
+
+Agent Hops is a Discord bot written in Dart utilizing the [Nyxx Framework](https://github.com/l7ssha/nyxx), which fetches beer release information from [Systembevakningsagenten.se](https://systembevakningsagenten.se/). It also has the ability to get info from [untappd](https://untappd.com/) and send updates to specified channel when a user posts a new checkin.
+
+## Getting started
+
+Included in this repo is a `Dockerfile` and a `docker-compose.yaml` file to run the bot on a raspberry ARMv7.
+
+And no, I wont go into details on how to register a developer account and get a dev token for discord. There are plenty of tutorials on that already. But you should probably start [here.](https://discord.com/developers/docs/intro)
+
+### 1. Clone the repo to your raspberry
+
+```bash
+git clone https://github.com/oelburk/agentsbot.git
+```
+
+### 2. Run your favorite text-editor and open up the compose file (nano ftw)
+
+```bash
+cd agentsbot
+nano docker-compose.yml
+```
+
+### 3. Set your discord token and optional data path
+
+```yaml
+...
+    environment:
+      ## Set your discord token here
+      - DISCORD_TOKEN=YOUR TOKEN GOES HERE
+    volumes:
+      ## Optional: Set data path here, e.g ./my/data/path:/data
+      - ./data:/data
+```
+
+### 4. Run compose up
+
+```bash
+docker-compose up -d
+```
+
+If you are having build issues, see the chapter **Known issues** further down.
+
+### 5. Magic
+
+You're done, the bot should be running in a minute! :magic_wand:
+
+## Available commands
+
+The bot is built on using global slash commands, all commands are available to all users in your discord except `/setup` which only will work for admins.
+
+| Command    | Parameter          | Description                                                                                                                                                  |
+| ---------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `/help`    | -                  | Lists all available commands.                                                                                                                                |
+| `/oel`     | -                  | Posts the latest beer releases available at systembevakningsagenten.se                                                                                       |
+| `/regga`   | -                  | Register for automatic beer release reminders.se                                                                                                             |
+| `/stopp`   | -                  | Unregister for automatic beer release reminders.                                                                                                             |
+| `/release` | `YYYY-MM-dd`       | Posts the release for given date in the format YYYY-MM-dd.                                                                                                   |
+| `/untappd` | `untappd username` | Let the bot know your untappd username so it can post automatic updates from your untappd account.                                                           |
+| `/setup`   | -                  | Setup the bot to post untappd updates to the current channel. Only admins can issue this command. Also, this is needed before any untappd updates can occur. |
+
+## Known issues
+
+The Dockerfile can fail in some `os_linux.cc` file when running the pub get command, if that's the case be sure to update the `libseccom2` lib on the raspberry. See below for workaround.
+
+> Thanks @a-siva
+>
+> That led me to [Raspberry Pi: clock_gettime(CLOCK_MONOTONIC, _) failed: Operation not permitted (1)](https://github.com/adriankumpf/teslamate/issues/2302) and from there to [Fix/Workaround - libseccomp2](https://blog.samcater.com/fix-workaround-rpi4-docker-libseccomp2-docker-20/). So I've installed the backported libseccomp2 and now my Dart app is building OK again with Dart 2.16.1 inside Docker on Raspberry Pi OS 10 Buster.
+>
+> ```shell
+> # Get signing keys to verify the new packages, otherwise they will not install
+> sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC 648ACFD622F3D138
+> 
+> # Add the Buster backport repository to apt sources.list
+> echo 'deb http://httpredir.debian.org/debian buster-backports main contrib non-free' \
+>  | sudo tee -a /etc/apt/sources.list.d/debian-backports.list
+> 
+> sudo apt update
+> sudo apt install libseccomp2 -t buster-backports
+> ```
+>
+> Seems like a Raspberry Pi OS thing more than a Dart thing, so closing this issue. But hopefully other people who trip across the problem will find the workaround here.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,8 +8,3 @@ include: package:pedantic/analysis_options.yaml
 # linter:
 #   rules:
 #     - camel_case_types
-
-analyzer:
-    enable-experiment:
-    - non-nullable
-    - extension-methods

--- a/bin/beer_bot.dart
+++ b/bin/beer_bot.dart
@@ -41,7 +41,7 @@ void main(List<String> arguments) {
   ELAPSED_SINCE_UPDATE = Stopwatch();
 
   bot.eventsWs.onReady.listen((e) {
-    print('Agent S is ready!');
+    print('Agent Hops is ready!');
   });
 
   Timer.periodic(Duration(hours: 6), (timer) => updateSubscribers());
@@ -82,7 +82,7 @@ void checkUntappd() async {
         // Build update message with info from untappd checkin
         var user = await bot.fetchUser(Snowflake(userSnowflake));
         var embedBuilder = EmbedBuilder();
-        embedBuilder.title = '${user.username} dricker öl!';
+        embedBuilder.title = '${user.username} is drinking beer!';
         embedBuilder.url = UntappdService.getCheckinUrl(
             latestCheckinUntappd.id, untappdUsername);
         embedBuilder.description = latestCheckinUntappd.title;
@@ -152,17 +152,17 @@ Future<void> updateSubscribers() async {
       });
 
       var updateMessage = MessageBuilder()
-        ..append(':beers: Hej!')
+        ..append(':beers: Hey!')
         ..appendNewLine()
-        ..append('Kom ihåg ölsläppet imorgon, ')
+        ..append('There is a fresh beer release tomorrow, ')
         ..appendBold(DateFormat('yyyy-MM-dd').format(saleDate))
-        ..append('. Bolaget öppnar 10:00')
+        ..append('. Bolaget opens 10:00')
         ..appendNewLine()
-        ..append('Det finns ')
+        ..append('There are ')
         ..appendBold(beers.length.toString())
-        ..append(' nya öl imorgon.')
+        ..append(' new beers tomorrow.')
         ..appendNewLine()
-        ..append('Mer info hittar du på https://systembevakningsagenten.se/')
+        ..append('For more info, visit https://systembevakningsagenten.se/')
         ..appendNewLine()
         ..appendNewLine()
         ..append(beersStr);

--- a/bin/beer_bot.dart
+++ b/bin/beer_bot.dart
@@ -10,11 +10,11 @@ import 'commands.dart';
 import 'utils.dart';
 import 'package:intl/intl.dart';
 
-String BOT_TOKEN = Platform.environment['DISCORD_TOKEN'];
-Stopwatch ELAPSED_SINCE_UPDATE;
+String BOT_TOKEN = Platform.environment['DISCORD_TOKEN'] ?? '';
+late final Stopwatch ELAPSED_SINCE_UPDATE;
 List<BeerList> BEER_SALES = <BeerList>[];
 int REFRESH_THRESHOLD = 14400000;
-INyxxWebsocket bot;
+late final INyxxWebsocket bot;
 
 void main(List<String> arguments) {
   bot =
@@ -38,11 +38,14 @@ void main(List<String> arguments) {
     print('Agent S is ready!');
   });
 
-  Timer.periodic(Duration(hours: 6), updateTimeout);
+  Timer.periodic(Duration(hours: 6), (timer) => updateSubscribers());
+
+  Timer.periodic(Duration(minutes: 15), (timer) => checkUntappd());
 }
 
-void updateTimeout(Timer timer) {
-  updateSubscribers();
+void checkUntappd() async {
+  var myFile = File('untappd.dat');
+  if (!await myFile.exists()) return;
 }
 
 Future<void> updateSubscribers() async {

--- a/bin/beer_bot.dart
+++ b/bin/beer_bot.dart
@@ -52,7 +52,7 @@ void main(List<String> arguments) {
 void checkUntappd() async {
   var box = await Hive.box(HiveConstants.untappdBox);
 
-  var listOfUsers =
+  Map<dynamic, dynamic> listOfUsers =
       await box.get(HiveConstants.untappdUserList, defaultValue: {});
   var latestCheckins =
       await box.get(HiveConstants.untappdLatestUserCheckins, defaultValue: {});
@@ -90,7 +90,7 @@ void checkUntappd() async {
             field: EmbedFieldBuilder('Comment', latestCheckinUntappd.comment));
         embedBuilder.addField(
             field: EmbedFieldBuilder('Rating',
-                _buildRatingEmoji(int.parse(latestCheckinUntappd.rating))));
+                _buildRatingEmoji(double.parse(latestCheckinUntappd.rating))));
         if (latestCheckinUntappd.photoAddress != null) {
           embedBuilder.imageUrl = latestCheckinUntappd.photoAddress;
         }
@@ -102,22 +102,21 @@ void checkUntappd() async {
 
         // Send update message
         await updateChannel.sendMessage(MessageBuilder.embed(embedBuilder));
-
-        // Sleep 5 seconds per user to avoid suspicious requests to untappd server
-        sleep(Duration(seconds: 5));
       }
+      // Sleep 5 seconds per user to avoid suspicious requests to untappd server
+      await Future.delayed(Duration(seconds: 5));
     } catch (e) {
       print(e.toString());
     }
   });
 }
 
-String _buildRatingEmoji(int rating) {
+String _buildRatingEmoji(double rating) {
   var ratingString = '';
-  for (var i = 0; i < rating; i++) {
+  for (var i = 0; i < rating.toInt(); i++) {
     ratingString += ':beer: ';
   }
-  return ratingString;
+  return '$ratingString ($rating)';
 }
 
 Future<void> updateSubscribers() async {

--- a/bin/beer_bot.dart
+++ b/bin/beer_bot.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ffi';
 import 'package:hive/hive.dart';
 import 'package:nyxx/nyxx.dart';
 import 'package:http/http.dart' as http;
@@ -21,7 +20,7 @@ int REFRESH_THRESHOLD = 14400000;
 late final INyxxWebsocket bot;
 
 void main(List<String> arguments) {
-  Hive.init('./');
+  Hive.init('./data');
   Hive.openBox(HiveConstants.untappdBox);
 
   bot =

--- a/bin/beer_bot.dart
+++ b/bin/beer_bot.dart
@@ -86,11 +86,18 @@ void checkUntappd() async {
         embedBuilder.url = UntappdService.getCheckinUrl(
             latestCheckinUntappd.id, untappdUsername);
         embedBuilder.description = latestCheckinUntappd.title;
-        embedBuilder.addField(
-            field: EmbedFieldBuilder('Comment', latestCheckinUntappd.comment));
-        embedBuilder.addField(
-            field: EmbedFieldBuilder('Rating',
-                _buildRatingEmoji(double.parse(latestCheckinUntappd.rating))));
+        if (latestCheckinUntappd.comment.isNotEmpty) {
+          embedBuilder.addField(
+              field:
+                  EmbedFieldBuilder('Comment', latestCheckinUntappd.comment));
+        }
+        if (latestCheckinUntappd.rating.isNotEmpty) {
+          embedBuilder.addField(
+              field: EmbedFieldBuilder(
+                  'Rating',
+                  _buildRatingEmoji(
+                      double.parse(latestCheckinUntappd.rating))));
+        }
         if (latestCheckinUntappd.photoAddress != null) {
           embedBuilder.imageUrl = latestCheckinUntappd.photoAddress;
         }

--- a/bin/beer_bot.dart
+++ b/bin/beer_bot.dart
@@ -20,7 +20,7 @@ int REFRESH_THRESHOLD = 14400000;
 late final INyxxWebsocket bot;
 
 void main(List<String> arguments) {
-  Hive.init('./data');
+  Hive.init('/data');
   Hive.openBox(HiveConstants.untappdBox);
 
   bot =

--- a/bin/constants/hive_constants.dart
+++ b/bin/constants/hive_constants.dart
@@ -1,0 +1,6 @@
+class HiveConstants {
+  static String get untappdBox => 'untappdBox';
+  static String get untappdUpdateChannelId => 'updateChannelId';
+  static String get untappdUserList => 'users';
+  static String get untappdLatestUserCheckins => 'userCheckins';
+}

--- a/bin/untapped_service.dart
+++ b/bin/untapped_service.dart
@@ -1,0 +1,87 @@
+import 'package:web_scraper/web_scraper.dart';
+
+class UntappdService {
+  /// Check validility of the username provided
+  ///
+  /// Will return true if given username has at least one checkin on Untappd.
+  static Future<bool> isValidUsername(String untappdUsername) async {
+    final webScraper = WebScraper('https://untappd.com');
+    if (await webScraper.loadWebPage('/user/$untappdUsername')) {
+      final checkins = webScraper.getElementAttribute(
+          'div#main-stream > *', 'data-checkin-id');
+
+      if (checkins.isEmpty) {
+        return false;
+      }
+      return true;
+    } else {
+      throw 'Error during fetching of Untappd data';
+    }
+  }
+
+  /// Get latest checkin for given username
+  static Future<UntappdCheckin?> getLatestCheckin(
+      String untappdUsername) async {
+    final webScraper = WebScraper('https://untappd.com');
+    if (await webScraper.loadWebPage('/user/$untappdUsername')) {
+      final checkins = webScraper.getElementAttribute(
+          'div#main-stream > *', 'data-checkin-id');
+
+      if (checkins.isEmpty) {
+        throw 'No checkins are available for $untappdUsername';
+      }
+
+      var latestCheckin = checkins.first!;
+
+      var baseCheckinAddress =
+          'div#main-stream > #checkin_$latestCheckin > div.checkin > div.top';
+
+      final checkinTitle = webScraper
+          .getElementTitle('$baseCheckinAddress > p.text')
+          .first
+          .trim();
+
+      final String checkinRating = webScraper.getElement(
+          '$baseCheckinAddress > div.checkin-comment > div.rating-serving > div.caps ',
+          ['data-rating']).first['attributes']['data-rating'];
+
+      final checkinComment = webScraper
+          .getElementTitle(
+              '$baseCheckinAddress > div.checkin-comment > p.comment-text')
+          .first
+          .trim();
+
+      final photo = webScraper.getElementAttribute(
+          '$baseCheckinAddress > p.photo > a > img', 'data-original');
+      final checkinPhotoAddress = photo.isNotEmpty ? photo.first : null;
+
+      return UntappdCheckin(
+          id: latestCheckin,
+          title: checkinTitle,
+          rating: checkinRating,
+          comment: checkinComment,
+          photoAddress: checkinPhotoAddress);
+    }
+    return null;
+  }
+}
+
+class UntappdCheckin {
+  const UntappdCheckin({
+    required this.id,
+    required this.title,
+    required this.rating,
+    required this.comment,
+    this.photoAddress,
+  });
+  final String id;
+  final String title;
+  final String rating;
+  final String comment;
+  final String? photoAddress;
+
+  @override
+  String toString() {
+    return 'title: $title\nrating: $rating\ncomment: $comment\nphoto url: $photoAddress\n';
+  }
+}

--- a/bin/untapped_service.dart
+++ b/bin/untapped_service.dart
@@ -1,7 +1,7 @@
 import 'package:web_scraper/web_scraper.dart';
 
 class UntappdService {
-  /// Check validility of the username provided
+  /// Check validity of the username provided
   ///
   /// Will return true if given username has at least one checkin on Untappd.
   static Future<bool> isValidUsername(String untappdUsername) async {
@@ -63,6 +63,11 @@ class UntappdService {
           photoAddress: checkinPhotoAddress);
     }
     return null;
+  }
+
+  /// Get untappd detailed checkin URL
+  static String getCheckinUrl(String checkinId, String username) {
+    return 'https://untappd.com/user/$username/checkin/$checkinId';
   }
 }
 

--- a/bin/untapped_service.dart
+++ b/bin/untapped_service.dart
@@ -36,20 +36,23 @@ class UntappdService {
       var baseCheckinAddress =
           'div#main-stream > #checkin_$latestCheckin > div.checkin > div.top';
 
-      final checkinTitle = webScraper
-          .getElementTitle('$baseCheckinAddress > p.text')
-          .first
-          .trim();
+      final checkinTitleElement =
+          webScraper.getElementTitle('$baseCheckinAddress > p.text');
+      final checkinTitle =
+          checkinTitleElement.isEmpty ? '' : checkinTitleElement.first.trim();
 
-      final String checkinRating = webScraper.getElement(
+      final checkinRatingElement = webScraper.getElement(
           '$baseCheckinAddress > div.checkin-comment > div.rating-serving > div.caps ',
-          ['data-rating']).first['attributes']['data-rating'];
+          ['data-rating']);
+      final String checkinRating = checkinRatingElement.isEmpty
+          ? '0'
+          : checkinRatingElement.first['attributes']['data-rating'];
 
-      final checkinComment = webScraper
-          .getElementTitle(
-              '$baseCheckinAddress > div.checkin-comment > p.comment-text')
-          .first
-          .trim();
+      final checkinCommentElement = webScraper.getElementTitle(
+          '$baseCheckinAddress > div.checkin-comment > p.comment-text');
+      final checkinComment = checkinCommentElement.isEmpty
+          ? ''
+          : checkinCommentElement.first.trim();
 
       final photo = webScraper.getElementAttribute(
           '$baseCheckinAddress > p.photo > a > img', 'data-original');

--- a/bin/utils.dart
+++ b/bin/utils.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:nyxx/nyxx.dart';
 import 'dart:io';
 
+import 'untapped_service.dart';
+
 Future<Map<String, dynamic>> httpGetRequest(String getURL) async {
   final response = await http.get(Uri.parse(getURL));
 
@@ -64,4 +66,30 @@ Future<void> unsubUser(INyxxWebsocket bot, Snowflake userSnowflake) async {
 Future<void> subUser(Snowflake userSnowflake) async {
   var myFile = File('sub.dat');
   await myFile.writeAsString(userSnowflake.toString(), mode: FileMode.append);
+}
+
+Future<bool> isUserUntappdRegistered(
+    Snowflake userSnowflake, String username) async {
+  var myFile = File('untappd.dat');
+
+  var fileExists = await myFile.exists();
+  if (!fileExists) await myFile.create();
+
+  return false;
+}
+
+Future<bool> regUntappdUser(
+    Snowflake userSnowflake, String untappdUsername) async {
+  try {
+    if (!await UntappdService.isValidUsername(untappdUsername)) {
+      return false;
+    }
+    var untappdFile = File('untappd.dat');
+    await untappdFile.writeAsString(
+        '${userSnowflake.toString()};$untappdUsername',
+        mode: FileMode.append);
+    return true;
+  } catch (e) {
+    return false;
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+services:
+  agent_hops:
+    container_name: agent_hops
+    restart: unless-stopped
+    build: .
+    environment:
+      ## Set your discord token here
+      - DISCORD_TOKEN=1234567890
+    volumes:
+      ## Set data path here, e.g ./my/data/path:/data
+      - ./data:/data

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.17.1 <3.0.0'
 
 dependencies: 
+  hive: ^2.2.3
   intl: ^0.17.0
   nyxx: ^3.2.3
   nyxx_commander: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,14 +4,17 @@ version: 1.0.0
 homepage: https://github.com/oelburk/agentsbot
 
 environment:
-  sdk: '>2.8.0 <3.0.0'
+  sdk: '>=2.17.1 <3.0.0'
 
 dependencies: 
   intl: ^0.17.0
   nyxx: ^3.2.3
   nyxx_commander: ^3.0.0
   nyxx_interactions: ^3.3.0
+  web_scraper: ^0.1.4
  
 
 dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0
   pedantic: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   intl: ^0.17.0
   nyxx: ^3.2.3
   nyxx_commander: ^3.0.0
-  nyxx_interactions: ^3.3.0
+  nyxx_interactions: ^4.2.1
   web_scraper: ^0.1.4
  
 


### PR DESCRIPTION
Updated Dart SDK along with some package updates. Also added ability to scrape untappd users and post their most recent checkin to assigned discord channel. Along with the updated SDK some changes were made to ensure null safety, this needs to be addressed further to make it look better IMO but OK for now.

The setup command register the current channel snowflake which will then be used by the bot to post the updates to. This command can only be issued by the discord server admins.

On top of that I added Hive support to better handle write/read to disk. To improve on this further the docker capability extended so now a volume is mounted to the container. This means the bot will now persist data between restarts. Next up is to migrate remind subscribers to Hive instead of using a file.

Speaking of Docker, the Dockerfile is completely rewritten. The file is now based on the official Dart image from the Dart team.